### PR TITLE
Added Whitelist for TOP Interupts

### DIFF
--- a/Kyber Vengeance DH Shadowlands (SpiritBomb Build)/rotation.cs
+++ b/Kyber Vengeance DH Shadowlands (SpiritBomb Build)/rotation.cs
@@ -268,6 +268,15 @@ namespace AimsharpWow.Modules
             bool Casting326607 = Aimsharp.CastingID("focus") == 326607; // Turn To Stone 
             bool Casting323552 = Aimsharp.CastingID("focus") == 323442; // Volley Of Power
             bool Casting325876 = Aimsharp.CastingID("focus") == 325876; // Curse Of Obliteration
+	    
+	    //TOP Interupts IDs
+            bool Casting330784 = Aimsharp.CastingID("focus") == 330784; // Necrotic Bolt
+            bool Casting330562 = Aimsharp.CastingID("focus") == 330562; // Demoralizing Shout 
+            bool Casting341977 = Aimsharp.CastingID("focus") == 341977; // Meat Shield
+            bool Casting341969 = Aimsharp.CastingID("focus") == 341969; // Withering Discharge
+            bool Casting370875 = Aimsharp.CastingID("focus") == 330875; // Spirit Frost
+            bool Casting330868 = Aimsharp.CastingID("focus") == 330868; // Necrotic Bolt Volley 
+            bool Casting342675 = Aimsharp.CastingID("focus") == 341977; // Bone Spear
 
             //Interrupt
             bool CanInterruptEnemy = Aimsharp.IsInterruptable();


### PR DESCRIPTION
	    //TOP Interupts IDs
            bool Casting330784 = Aimsharp.CastingID("focus") == 330784; // Necrotic Bolt
            bool Casting330562 = Aimsharp.CastingID("focus") == 330562; // Demoralizing Shout 
            bool Casting341977 = Aimsharp.CastingID("focus") == 341977; // Meat Shield
            bool Casting341969 = Aimsharp.CastingID("focus") == 341969; // Withering Discharge
            bool Casting370875 = Aimsharp.CastingID("focus") == 330875; // Spirit Frost
            bool Casting330868 = Aimsharp.CastingID("focus") == 330868; // Necrotic Bolt Volley 
            bool Casting342675 = Aimsharp.CastingID("focus") == 341977; // Bone Spear